### PR TITLE
Exchange type & value for filters (wrong switched fields)

### DIFF
--- a/packages/core/schema/index.graphql
+++ b/packages/core/schema/index.graphql
@@ -526,8 +526,8 @@ type Article {
 Value of a product list filter
 """
 type ProductListFilterValue {
-  type: String!
-  value: AttributeType!
+  type: AttributeType!
+  value: String!
   applied: Boolean!
   count: Int!
 }


### PR DESCRIPTION
The `ProductListFilterValue` has mixed the content of `value` and `type`, probably only a typo 