### PR TITLE
Add authentication mutation

### DIFF
--- a/packages/core/schema/index.graphql
+++ b/packages/core/schema/index.graphql
@@ -944,6 +944,15 @@ type Customer {
   addresses: [CustomerAddress!]!
 }
 
+type AuthResult {
+  id: ID!
+  authToken: String
+  refreshToken: String
+  expiresIn: String
+  customer: Customer
+  errors: [Error]
+}
+
 """
 Result of adding one or many articles to the cart
 """
@@ -1137,6 +1146,15 @@ input RegistrationInput {
 }
 
 """
+Authentication data for login
+"""
+input AuthInput {
+  user: String
+  password: String
+  refreshToken: String
+}
+
+"""
 Customer data to be updated
 """
 input UpdateCustomerInput {
@@ -1285,6 +1303,7 @@ type Mutation {
 
   register(data: RegistrationInput!): Customer
   updateCustomer(id: ID!, data: UpdateCustomerInput!): Customer
+  authenticate(data: AuthInput!): AuthResult
 
   createReservation(
     articleId: ID!


### PR DESCRIPTION
To be able to generate an initial token that can be send via `Authorization: Bearer <token>`  we need to provide a mutation to create such a token. This is possible by providing username & password or via a refresh token, depending on the use cases and possibilities of the connector.

In addition the `CustomerAddress` was wrongly named `Address` which resulted in a duplicated definition for addresses. Maybe we can set up a Github action to validate the graphql schema to avoid such issues in the future (e.g.: https://github.com/mandiwise/graphql-operation-validation-action)